### PR TITLE
Add corrections api documentation

### DIFF
--- a/api-reference/endpoint/correct_workflow_run.mdx
+++ b/api-reference/endpoint/correct_workflow_run.mdx
@@ -1,0 +1,57 @@
+---
+title: "Correct WorkflowRun Outputs"
+api: "POST https://api-prod.extend.app/v1/workflow_runs/:workflowRunId/outputs/:outputId"
+description: "Use this endpoint to submit corrected outputs for a WorkflowRun for future processor evaluation and tuning in Extend."
+---
+
+If you are using our Human-in-the-loop workflow review, then we already will be collecting your operator submitted corrections. However,
+if you are receiving data via the API without human review, there could be incorrect outputs that you would like to correct for future usage in evaluation and tuning within
+the Extend platform. This endpoint allows you to submit corrected outputs for a WorkflowRun, by providing the correct output for a given output ID.
+
+The output ID, would be found in a given entry within the `outputs` arrays of a [WorkflowRun payload](/api-reference/objects/workflow_run).
+The ID would look something like `dpr_gwkZZNRrPgkjcq0y-***`.
+
+When using this endpoint, you will need to provide both the run id and the ouput id as parameters, and the corrected `reviewedOutput` as the body of the request. See below for more details.
+
+### Parameters
+
+<ParamField path="workflowRunId" type="string">
+  The ID of the WorkflowRun that incldued this initial output.
+</ParamField>
+
+<ParamField path="outputId" type="string">
+  The ID of the output that these corrections are for.
+</ParamField>
+
+### Body
+
+<ParamField body="reviewedOutput" type="object" required>
+  The corrected output of the processor when run against the file. 
+  
+  This should be a JSON object conforming to the [output type schema](/api-reference/guides/output_types) of the given processor.
+
+  If this is an extraction result, you can include all fields, or just the ones that were corrected, our system will handle merges/dedupes. However, if you do include a field, we assume the value incldued in the final reviewed value.
+</ParamField>
+
+<RequestExample>
+```bash Example Request
+curl --location --request POST 'https://api-prod.extend.app/v1/workflow_runs/wr_123/outputs/dpr_123' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer <API_TOKEN>' \
+--data '{
+    "reviewedOutput": { # Corrected output
+      "field1": {
+        "id": "field_fsdf",
+        "type": "string",
+        "value": "Updated field output"
+      },
+      "field2": {
+        "id": "field_1234",
+        "type": "number",
+        "value": 1234
+      }
+    }
+}'
+```
+</RequestExample>
+

--- a/api-reference/endpoint/update_eval_set_item.mdx
+++ b/api-reference/endpoint/update_eval_set_item.mdx
@@ -14,7 +14,7 @@ If you need to change the expected output for a given evaluation set item, you c
 
 ### Body
 
-<ParamField body="expectedOutput" type="object" required>
+<ParamField body="expectedOutput" default="{ hi: 'hi' }" type="object" required>
   The expected output of the processor when run against the file. 
   
   This should be a JSON object conforming to the [output type schema](/api-reference/guides/output_types) of the processor.

--- a/mint.json
+++ b/mint.json
@@ -70,13 +70,24 @@
       ]
     },
     {
-      "group": "Endpoints",
+      "group": "Workflow Endpoints",
       "pages": [
         "api-reference/endpoint/run_workflow",
         "api-reference/endpoint/get_workflow_run",
         "api-reference/endpoint/update_workflow_run",
+        "api-reference/endpoint/correct_workflow_run"
+      ]
+    },
+    {
+      "group": "File Endpoints",
+      "pages": [
         "api-reference/endpoint/create_file",
-        "api-reference/endpoint/get_file",
+        "api-reference/endpoint/get_file"
+      ]
+    },
+    {
+      "group": "Evaluation Set Endpoints",
+      "pages": [
         "api-reference/endpoint/create_eval_set",
         "api-reference/endpoint/create_eval_set_item",
         "api-reference/endpoint/update_eval_set_item",


### PR DESCRIPTION
Adds a new doc page for the corrections endpoint. Also reorganized the tabs to group endpoints because it was getting to be a lot to look at.

<img width="1624" alt="Screenshot 2024-06-14 at 12 51 41 PM" src="https://github.com/extend-hq/documentation/assets/26079608/4c25d77f-9892-435d-8fce-5fede991147e">
<img width="1624" alt="Screenshot 2024-06-14 at 12 51 37 PM" src="https://github.com/extend-hq/documentation/assets/26079608/f978718f-d4d9-4d23-99a7-f0ecb6f342d3">
