### PR TITLE
Add base processor changelog to docs

### DIFF
--- a/changelog/classification/classification_light.mdx
+++ b/changelog/classification/classification_light.mdx
@@ -1,0 +1,12 @@
+---
+title: "Classification Light"
+description: "Changelog for the Classification Light base processor in Extend."
+---
+
+Our low latency, low cost classification processor. This processor aims to be the fastest and cheapest option available, while still maintaining high precision and recall.
+
+## Versions
+
+| Version | Date | Changelog |
+|---------|----|-----------|
+| `1.0.0`   | <div style={{ whiteSpace: "nowrap" }}>2024-05-14</div> | Initial light tier classification processor and model. |

--- a/changelog/classification/classification_performance.mdx
+++ b/changelog/classification/classification_performance.mdx
@@ -1,0 +1,15 @@
+---
+title: "Classification Performance"
+description: "Changelog for the Classification Performance base processor in Extend."
+---
+
+Our highest performance (in terms of accuracy and reliability) base classification processor. Always stays up to date with the best foundation models available across all of our benchmarks.
+
+## Versions
+
+| Version | Date | Changelog |
+|---------|---- |-----------|
+| `3.0.0`   | <div style={{ whiteSpace: "nowrap" }}>2024-05-14</div> | Promoting a new foundation model to default - it's faster and more accurate across all of our internal benchmarks for classification. |
+| `2.1.0`   | <div style={{ whiteSpace: "nowrap" }}>2024-05-01</div> | Adds support for classification rules and reminders. |
+| `2.0.0`   | <div style={{ whiteSpace: "nowrap" }}>2024-04-12</div> | Promoting a new foundation model to default. Very minor increases in accuracy and speed. |
+| `1.0.0`   | <div style={{ whiteSpace: "nowrap" }}>2023-08-01</div> | Initial (and now legacy) classification model and processor. |

--- a/changelog/extraction/extraction_light.mdx
+++ b/changelog/extraction/extraction_light.mdx
@@ -1,0 +1,14 @@
+---
+title: "Extraction Light"
+description: "Changelog for the Extraction Light base processor in Extend."
+---
+
+Our low latency, low cost extraction processor. This processor aims to be the fastest and cheapest option available, while still maintaining a very high degree of accuracy.
+
+## Versions
+
+| Version | Date | Changelog |
+|---------|----|-----------|
+| `2.1.0`   | <div style={{ whiteSpace: "nowrap" }}>2024-07-01</div> | Updates to our document pre-processing to better handle more complex document/table layouts. |
+| `2.0.0`   | <div style={{ whiteSpace: "nowrap" }}>2024-04-01</div> | Rolls out a new foundation model for the light extraction processor. Significantly more accurate, with little to no latency increase. |
+| `1.0.0`   | <div style={{ whiteSpace: "nowrap" }}>2023-09-01</div> | Initial (and now legacy) light tier extraction model. |

--- a/changelog/extraction/extraction_performance.mdx
+++ b/changelog/extraction/extraction_performance.mdx
@@ -1,0 +1,15 @@
+---
+title: "Extraction Performance"
+description: "Changelog for the Extraction Performance base processor in Extend."
+---
+
+Our highest performance (in terms of accuracy and reliability) base extraction processor. Always stays up to date with the best foundation models available across all of our benchmarks.
+
+# Versions
+
+| Version   | Date       | Changelog |
+|---------- |----------- |-----------|
+| `3.1.0`   | <div style={{ whiteSpace: "nowrap" }}>2024-06-01</div> | Updates to our document pre-processing to better handle more complex document/table layouts. |
+| `3.0.0`   | <div style={{ whiteSpace: "nowrap" }}>2024-05-14</div> | Promoting a new foundation model to default - it's faster and more accurate across all of our internal benchmarks for extraction. |
+| `2.0.0`   | <div style={{ whiteSpace: "nowrap" }}>2024-04-12</div> | Promoting a new foundation model to default. Very minor increases in accuracy and speed. |
+| `1.0.0`   | <div style={{ whiteSpace: "nowrap" }}>2023-08-01</div> | Initial (and now legacy) extraction model. |

--- a/changelog/overview.mdx
+++ b/changelog/overview.mdx
@@ -1,0 +1,69 @@
+---
+title: "Overview"
+description: "What base processors are and how they are versioned."
+---
+
+## What are Base Processors?
+
+Base processors are the fundamental building blocks of our processing system. They control the underlying, base configuration for each processor, encompassing various critical components:
+
+- Foundation model(s) used
+- The OCR models applied in pre-processing
+- Other pre-processing methods used to clean and prepare data for the LLM
+- Post-processing rules
+- Internal validation schemes
+- Multimodal vs. non-multimodal processing
+- Base prompting strategies
+- And other core functionalities surrounding the execution of a given processor
+
+These base configurations are essential in determining the overall performance, accuracy, and capabilities of our processing system across different use cases.
+
+## Versioning System
+
+We employ a semantic versioning system for our base processors. This system allows us to communicate the nature and impact of changes clearly. Our version numbers follow the format: `MAJOR.MINOR.PATCH`
+
+### Major Version Updates (X.0.0)
+
+Major version updates are reserved for changes that can potentially affect accuracy, latency, or reliability across every use case. The expectation is that 
+a major version update would guaranteed impact all users of the processor, and any consumer should expect to see changes in their output when upgrading to a new major version.
+
+These include changes such as:
+
+- Updates to the underlying model and downstream version
+  - We generally avoid upgrading to new models at the base layer unless there's a significant, across-the-board benefit. Use case specific upgrades might still occur in an override fashion for your use case (which would be communicated separately).
+- Changes to the entire structure of our base prompting system
+- Fundamental changes to how a given processor works/or is configured
+- Modifications that affect how data interacts with consumers of the API
+- etc.
+
+### Minor Version Updates (0.X.0)
+
+Minor version updates are for changes that could cause potentially significant changes to specific use cases, but not necessarily all use cases. 
+
+Examples include:
+- Adding a new field type for extraction, e.g. the `signature` type or `enum` type
+- Introducing a new set of base prompt rule for specific data types to improve accuracy
+- Making backwards compatible, but still material changes to the underlying processor model
+- etc.
+
+### Patch Version Updates (0.0.X)
+
+Patch updates are for changes that are not expected to meaningfully impact functionality in any way outside of very few isolated cases. 
+
+These might include:
+- Addressing a bug in the processor that only affects a small subset of use cases
+- Fixing typos in prompts
+- Adjusting newlines or spacing in prompts
+- etc.
+
+## Importance of Versioning
+
+Understanding our versioning system is crucial for developers and users of our base processors. It allows you to:
+
+1. Anticipate the potential impact of updates on your specific use cases
+2. Make informed decisions about when to upgrade to newer versions
+3. Maintain consistency and reliability in your applications that depend on our base processors
+
+We strive to provide detailed changelogs for each version update, ensuring you have all the information needed to understand the changes and their potential impacts on your workflows.
+
+If you have any questions or need further clarification on our versioning system, please reach out to us on Slack.

--- a/mint.json
+++ b/mint.json
@@ -15,6 +15,10 @@
     {
       "name": "API Reference",
       "url": "api-reference"
+    },
+    {
+      "name": "Changelog",
+      "url": "changelog"
     }
   ],
   "navigation": [
@@ -121,6 +125,26 @@
       "group": "Integrations",
       "pages": [
         "api-reference/integrations/slack"
+      ]
+    },
+    {
+      "group": "Changelog",
+      "pages": [
+        "changelog/overview"
+      ]
+    },
+    {
+      "group": "Extraction",
+      "pages": [
+        "changelog/extraction/extraction_performance",
+        "changelog/extraction/extraction_light"
+      ]
+    },
+    {
+      "group": "Classification",
+      "pages": [
+        "changelog/classification/classification_performance",
+        "changelog/classification/classification_light"
       ]
     }
   ],


### PR DESCRIPTION
In the future, we will put this directly into the product ui so we can generate it from the underlying yaml files, but it's just not worth effort to build out that ui right now. This is a solid v1 imo:

<img width="1624" alt="Screenshot 2024-07-15 at 10 13 58 AM" src="https://github.com/user-attachments/assets/740058dc-f9db-4608-b9ed-adcc6b1637f4">
<img width="1624" alt="Screenshot 2024-07-15 at 10 14 02 AM" src="https://github.com/user-attachments/assets/c0e51bfd-b135-40f0-b986-db986dba8498">
